### PR TITLE
Feat/ Updating user entity schema and saving mainAddressId on registerAddress endpoint

### DIFF
--- a/src/modules/user/entities/User.ts
+++ b/src/modules/user/entities/User.ts
@@ -33,6 +33,10 @@ export class User {
     @MinLength(6)
     private password: string;
 
+    @IsString()
+    @IsNotEmpty()
+    private mainAddressId?: string
+
     constructor(
         id: string,
         name: string,
@@ -50,7 +54,7 @@ export class User {
     }
 
     public getUser() {
-        const { id, name, email, password, cpf, hasAddress } = this;
+        const { id, name, email, password, cpf, hasAddress, mainAddressId } = this;
         return {
             id,
             name,
@@ -58,6 +62,7 @@ export class User {
             password,
             cpf,
             hasAddress,
+            mainAddressId
         };
     }
 }

--- a/src/modules/user/entities/User.ts
+++ b/src/modules/user/entities/User.ts
@@ -35,7 +35,7 @@ export class User {
 
     @IsString()
     @IsNotEmpty()
-    private mainAddressId?: string
+    private mainAddressId?: string;
 
     constructor(
         id: string,
@@ -53,8 +53,17 @@ export class User {
         this.hasAddress = hasAddress;
     }
 
-    public getUser() {
-        const { id, name, email, password, cpf, hasAddress, mainAddressId } = this;
+    public getUser(): {
+        id: string;
+        name: string;
+        email: string;
+        password: string;
+        hasAddress: boolean;
+        cpf: string;
+        mainAddressId?: string;
+    } {
+        const { id, name, email, password, cpf, hasAddress, mainAddressId } =
+            this;
         return {
             id,
             name,
@@ -62,7 +71,7 @@ export class User {
             password,
             cpf,
             hasAddress,
-            mainAddressId
+            mainAddressId,
         };
     }
 }

--- a/src/modules/user/repository/UserRepository.ts
+++ b/src/modules/user/repository/UserRepository.ts
@@ -55,4 +55,8 @@ export class UserRepository extends Database {
         const { hasAddress } = flag;
         return await this.update(userId, { hasAddress });
     }
+
+    async setMainAddressId(userId: string, addressId: string): Promise<void> {
+        return await this.update(userId, { mainAddressId: addressId });
+    }
 }

--- a/src/modules/user/repository/__tests__/UserRepository.test.ts
+++ b/src/modules/user/repository/__tests__/UserRepository.test.ts
@@ -29,6 +29,7 @@ const userAddress = {
 describe('UserRepository test', () => {
     let userRepository: UserRepository;
     const mockInsert = jest.fn();
+    const mockUpdate = jest.fn();
     let databaseMock: DatabaseTestContext;
     beforeEach(() => {
         databaseMock = new DatabaseTestContext();
@@ -69,8 +70,8 @@ describe('UserRepository test', () => {
             mockInsert(USER_COLLECTIONS.USER_ADDRESS, userId, userAddress);
         });
         jest.spyOn(Database.prototype, 'update').mockImplementation(
-            (userId, { hasAddress }) => {
-                mockInsert(userId, { hasAddress });
+            (userId, { hasAddress, mainAddressId }) => {
+                mockUpdate(userId, { hasAddress, mainAddressId });
             }
         );
     });
@@ -112,7 +113,14 @@ describe('UserRepository test', () => {
         await userRepository.updateUserAddressFlag(user.id, {
             hasAddress: true,
         });
-        expect(mockInsert).toHaveBeenCalled();
-        expect(mockInsert).toHaveBeenCalledWith(user.id, { hasAddress: true });
+        expect(mockUpdate).toHaveBeenCalled();
+        expect(mockUpdate).toHaveBeenCalledWith(user.id, { hasAddress: true });
+    });
+    it('should call setMainAddressId correctly', async () => {
+        await userRepository.setMainAddressId(user.id, 'addressId');
+        expect(mockUpdate).toHaveBeenCalled();
+        expect(mockUpdate).toHaveBeenCalledWith(user.id, {
+            mainAddressId: 'addressId',
+        });
     });
 });

--- a/src/modules/user/resolvers.ts
+++ b/src/modules/user/resolvers.ts
@@ -12,18 +12,6 @@ import { RegisterAddressUseCase } from './useCases/RegisterAddressUseCase';
 
 export const resolvers = {
     Mutation: {
-        login: async (
-            _parent: any,
-            args: { input: LoginInput },
-            context: IDatabaseContext
-        ) => {
-            const loginController = new LoginController(
-                // @ts-expect-error impossible undefined
-                new LoginUseCase(Container.get(context.userDatabaseContext))
-            );
-            const { email, password } = JSON.parse(JSON.stringify(args)).input;
-            return loginController.login({ email, password });
-        },
         signup: async (
             _parent: any,
             args: { input: SignupInput },
@@ -37,6 +25,18 @@ export const resolvers = {
                 JSON.stringify(args)
             ).input;
             return signupController.signup({ name, cpf, email, password });
+        },
+        login: async (
+            _parent: any,
+            args: { input: LoginInput },
+            context: IDatabaseContext
+        ) => {
+            const loginController = new LoginController(
+                // @ts-expect-error impossible undefined
+                new LoginUseCase(Container.get(context.userDatabaseContext))
+            );
+            const { email, password } = JSON.parse(JSON.stringify(args)).input;
+            return loginController.login({ email, password });
         },
         registerAddress: async (
             _parent: any,

--- a/src/modules/user/useCases/RegisterAddressUseCase.ts
+++ b/src/modules/user/useCases/RegisterAddressUseCase.ts
@@ -5,6 +5,8 @@ import { mapUserAddressEntityToResponse } from './mappers/mapUserAddressEntityTo
 import { UserRepository } from '../repository/UserRepository';
 import { USER_ERROR_MESSAGES } from './constants/errorMessages';
 
+// TODO: define and implement RN to handle with addressId updating (userRepository.setMainAddressId calling)
+
 @Service()
 export class RegisterAddressUseCase {
     constructor(private userRepository: UserRepository) {}
@@ -21,7 +23,8 @@ export class RegisterAddressUseCase {
         await this.userRepository.updateUserAddressFlag(userId, {
             hasAddress: true,
         });
-        // TODO: Create handleMainAddressId on userRepository
+        const { id } = address.getUserAddress();
+        await this.userRepository.setMainAddressId(userId, id);
         return mapUserAddressEntityToResponse(address);
     }
 }

--- a/src/modules/user/useCases/RegisterAddressUseCase.ts
+++ b/src/modules/user/useCases/RegisterAddressUseCase.ts
@@ -21,6 +21,7 @@ export class RegisterAddressUseCase {
         await this.userRepository.updateUserAddressFlag(userId, {
             hasAddress: true,
         });
+        // TODO: Create handleMainAddressId on userRepository
         return mapUserAddressEntityToResponse(address);
     }
 }

--- a/src/modules/user/useCases/RegisterAddressUseCase.ts
+++ b/src/modules/user/useCases/RegisterAddressUseCase.ts
@@ -5,8 +5,6 @@ import { mapUserAddressEntityToResponse } from './mappers/mapUserAddressEntityTo
 import { UserRepository } from '../repository/UserRepository';
 import { USER_ERROR_MESSAGES } from './constants/errorMessages';
 
-// TODO: define and implement RN to handle with addressId updating (userRepository.setMainAddressId calling)
-
 @Service()
 export class RegisterAddressUseCase {
     constructor(private userRepository: UserRepository) {}
@@ -24,6 +22,7 @@ export class RegisterAddressUseCase {
             hasAddress: true,
         });
         const { id } = address.getUserAddress();
+        // TODO: define and implement RN to handle with addressId updating (userRepository.setMainAddressId calling)
         await this.userRepository.setMainAddressId(userId, id);
         return mapUserAddressEntityToResponse(address);
     }

--- a/src/modules/user/useCases/__tests__/RegisterAddressUseCase.test.ts
+++ b/src/modules/user/useCases/__tests__/RegisterAddressUseCase.test.ts
@@ -1,7 +1,7 @@
 import { RegisterAddressUseCase } from '../RegisterAddressUseCase';
 import { RegisterAddressResponse } from '../interfaces/RegisterAddressResponse';
 
-const userId = "userId"
+const userId = 'userId';
 
 const input = {
     id: 'addressId',
@@ -11,6 +11,17 @@ const input = {
     streetNumber: '123',
     streetName: 'Guajajaras',
     zone: 'Barreiro',
+    getUserAddress: () => {
+        return {
+            id: 'addressId',
+            city: 'Lisbon',
+            complement: '1D',
+            state: 'MG',
+            streetNumber: '123',
+            streetName: 'Guajajaras',
+            zone: 'Barreiro',
+        };
+    },
 };
 
 const expectedResponse: RegisterAddressResponse = {
@@ -41,11 +52,11 @@ const mockCheckUserExistence = jest
         return id === userId;
     });
 
-const mockRegisterAddress = jest.fn()
+const mockRegisterAddress = jest.fn();
 
-const mockUpdateUserAddressFlag = jest.fn()
+const mockUpdateUserAddressFlag = jest.fn();
 
-const mockHandleMainAddressId = jest.fn()
+const mockSetMainAddressId = jest.fn();
 
 describe('RegisterAddressUseCase test', () => {
     let registerAddressUseCase: RegisterAddressUseCase;
@@ -53,9 +64,12 @@ describe('RegisterAddressUseCase test', () => {
         // @ts-expect-error dependency injection
         registerAddressUseCase = new RegisterAddressUseCase({
             checkUserExistence: (id: string) => mockCheckUserExistence(id),
-            registerAddress: (address, userId) => mockRegisterAddress(address, userId),
-            updateUserAddressFlag: (userId) => mockUpdateUserAddressFlag(userId, { hasAddress: true }),
-            // handleMainAddressId: (input, userId: string) => mockHandleMainAddressId(input.id, userId)
+            registerAddress: (address, userId) =>
+                mockRegisterAddress(address, userId),
+            updateUserAddressFlag: (userId) =>
+                mockUpdateUserAddressFlag(userId, { hasAddress: true }),
+            setMainAddressId: (userId, addressId) =>
+                mockSetMainAddressId(userId, addressId),
         });
     });
     it('should run execute method correctly', async () => {
@@ -66,8 +80,10 @@ describe('RegisterAddressUseCase test', () => {
         );
         expect(mockCheckUserExistence).toHaveBeenCalledWith(userId);
         expect(mockRegisterAddress).toHaveBeenCalledWith(input, userId);
-        expect(mockUpdateUserAddressFlag).toHaveBeenCalledWith(userId, { hasAddress: true });
-        expect(mockHandleMainAddressId).toHaveBeenCalledWith(userId, input.id)
+        expect(mockUpdateUserAddressFlag).toHaveBeenCalledWith(userId, {
+            hasAddress: true,
+        });
+        expect(mockSetMainAddressId).toHaveBeenCalledWith(userId, input.id);
         expect(response).toEqual(expectedResponse);
     });
     it('should throw error by userId not found', async () => {

--- a/src/modules/user/useCases/__tests__/RegisterAddressUseCase.test.ts
+++ b/src/modules/user/useCases/__tests__/RegisterAddressUseCase.test.ts
@@ -1,25 +1,16 @@
 import { RegisterAddressUseCase } from '../RegisterAddressUseCase';
 import { RegisterAddressResponse } from '../interfaces/RegisterAddressResponse';
 
+const userId = "userId"
+
 const input = {
-    userId: 'userId',
+    id: 'addressId',
     city: 'Lisbon',
     complement: '1D',
     state: 'MG',
     streetNumber: '123',
     streetName: 'Guajajaras',
     zone: 'Barreiro',
-    getUserAddress: () => {
-        return {
-            userId: 'userId',
-            city: 'Lisbon',
-            complement: '1D',
-            state: 'MG',
-            streetNumber: '123',
-            streetName: 'Guajajaras',
-            zone: 'Barreiro',
-        };
-    },
 };
 
 const expectedResponse: RegisterAddressResponse = {
@@ -47,8 +38,14 @@ jest.mock('../mappers/mapUserAddressEntityToResponse', () => ({
 const mockCheckUserExistence = jest
     .fn()
     .mockImplementation(async (id: string): Promise<boolean> => {
-        return id === input.userId;
+        return id === userId;
     });
+
+const mockRegisterAddress = jest.fn()
+
+const mockUpdateUserAddressFlag = jest.fn()
+
+const mockHandleMainAddressId = jest.fn()
 
 describe('RegisterAddressUseCase test', () => {
     let registerAddressUseCase: RegisterAddressUseCase;
@@ -56,17 +53,21 @@ describe('RegisterAddressUseCase test', () => {
         // @ts-expect-error dependency injection
         registerAddressUseCase = new RegisterAddressUseCase({
             checkUserExistence: (id: string) => mockCheckUserExistence(id),
-            registerAddress: jest.fn(),
-            updateUserAddressFlag: jest.fn(),
+            registerAddress: (address, userId) => mockRegisterAddress(address, userId),
+            updateUserAddressFlag: (userId) => mockUpdateUserAddressFlag(userId, { hasAddress: true }),
+            // handleMainAddressId: (input, userId: string) => mockHandleMainAddressId(input.id, userId)
         });
     });
     it('should run execute method correctly', async () => {
         const response = await registerAddressUseCase.execute(
-            // @ts-expect-error expect a class, I'm injecting a object with the same props
+            // @ts-expect-error class issue
             input,
-            input.userId
+            userId
         );
-        expect(mockCheckUserExistence).toHaveBeenCalledWith(input.userId);
+        expect(mockCheckUserExistence).toHaveBeenCalledWith(userId);
+        expect(mockRegisterAddress).toHaveBeenCalledWith(input, userId);
+        expect(mockUpdateUserAddressFlag).toHaveBeenCalledWith(userId, { hasAddress: true });
+        expect(mockHandleMainAddressId).toHaveBeenCalledWith(userId, input.id)
         expect(response).toEqual(expectedResponse);
     });
     it('should throw error by userId not found', async () => {

--- a/src/modules/user/useCases/__tests__/SignupUseCase.test.ts
+++ b/src/modules/user/useCases/__tests__/SignupUseCase.test.ts
@@ -59,14 +59,14 @@ describe('SignupUseCase test', () => {
         });
     });
     it('should run execute method correctly', async () => {
-        // @ts-expect-error expect a class, I'm injecting a object with the same props
+        // @ts-expect-error expect a class, It's injecting an object with the same props
         const response = await signupUseCase.execute(input);
         expect(mockCheckExistenceByEmail).toHaveBeenCalledWith(input.email);
         expect(response).toEqual(expectedResponse);
     });
     it('should throw error by email already existed on database', async () => {
         try {
-            // @ts-expect-error expect a class, I'm injecting a object with the same props
+            // @ts-expect-error expect a class, It's injecting an object with the same props
             await signupUseCase.execute({
                 ...input,
                 getUser: () => {

--- a/src/modules/user/useCases/interfaces/UserResponse.ts
+++ b/src/modules/user/useCases/interfaces/UserResponse.ts
@@ -5,4 +5,5 @@ export interface UserResponse {
     cpf: string;
     hasAddress: boolean;
     password: string;
+    mainAddressId?: string;
 }

--- a/src/modules/user/useCases/mappers/mapUserEntityToResponse.ts
+++ b/src/modules/user/useCases/mappers/mapUserEntityToResponse.ts
@@ -2,7 +2,8 @@ import { User } from '../../entities/User';
 import { UserResponse } from '../interfaces/UserResponse';
 
 export const mapUserEntityToResponse = (user: User): UserResponse => {
-    const { name, email, cpf, hasAddress, password, id, mainAddressId } = user.getUser();
+    const { name, email, cpf, hasAddress, password, id, mainAddressId } =
+        user.getUser();
     return {
         name,
         email,
@@ -10,6 +11,6 @@ export const mapUserEntityToResponse = (user: User): UserResponse => {
         hasAddress,
         password,
         id,
-        mainAddressId
+        mainAddressId,
     };
 };

--- a/src/modules/user/useCases/mappers/mapUserEntityToResponse.ts
+++ b/src/modules/user/useCases/mappers/mapUserEntityToResponse.ts
@@ -2,7 +2,7 @@ import { User } from '../../entities/User';
 import { UserResponse } from '../interfaces/UserResponse';
 
 export const mapUserEntityToResponse = (user: User): UserResponse => {
-    const { name, email, cpf, hasAddress, password, id } = user.getUser();
+    const { name, email, cpf, hasAddress, password, id, mainAddressId } = user.getUser();
     return {
         name,
         email,
@@ -10,5 +10,6 @@ export const mapUserEntityToResponse = (user: User): UserResponse => {
         hasAddress,
         password,
         id,
+        mainAddressId
     };
 };


### PR DESCRIPTION
## Proposed changes

Updating user entity schema. Now, an User also have a key called mainAddressId. This key is optional and will be updated on registerAddress endpoint calling. For now, every endpoint calling (registerAddress) will update this prop.

## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [x] New feature (non-breaking change which adds functionality)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I link this PR with the trello card

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
